### PR TITLE
Add 'builderCliOptions' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ field|description
 `linkPackages`|array of packages names you want to link (runs `npm link <packageName>` for every package listed)
 `packageJsonFields`|fields to add to the generated `package.json` in your desktop app
 `builderOptions`|[`electron-builder`](https://github.com/electron-userland/electron-builder) [options](https://github.com/electron-userland/electron-builder/wiki/Options)
+`builderCliOptions`|specify additional electron-builder CLI options e.g for [publishing artifacts](https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts)
 `packagerOptions`|[`electron-packager`](https://github.com/electron-userland/electron-packager) [options](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md)
 
 ##### Applying different window options for different OS

--- a/lib/desktop.js
+++ b/lib/desktop.js
@@ -231,6 +231,7 @@ export default class Desktop {
  * @property {Object} windowDev
  * @property {Object} packageJsonFields
  * @property {Object} builderOptions
+ * @property {Object} builderCliOptions
  * @property {Object} packagerOptions
  * @property {Object} plugins
  * @property {Object} dependencies

--- a/lib/electronBuilder.js
+++ b/lib/electronBuilder.js
@@ -154,10 +154,10 @@ export default class InstallerBuilder {
         };
 
         try {
-            await build({
+            await build(Object.assign({
                 targets: this.prepareTargets(),
                 config: builderOptions
-            });
+            }, settings.builderCliOptions));
         } catch (e) {
             this.log.error('error while building installer: ', e);
         }


### PR DESCRIPTION
We were blocked by this while trying to configure electron-builder to [publish artifacts](https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts).

Happy to hear your thoughts on an alternative interface.