### PR TITLE
Bugfix for Meteor 1.6

### DIFF
--- a/lib/meteorApp.js
+++ b/lib/meteorApp.js
@@ -113,7 +113,7 @@ export default class MeteorApp {
      * @returns {string}
      */
     castMeteorReleaseToSemver() {
-        return `${this.getMeteorRelease()}.0.0`.match(/(^\d+\.\d+\.\d+)/gmi)[0];
+        return `${parseFloat(this.getMeteorRelease())}.0.0`.match(/(^\d+\.\d+\.\d+)/gmi)[0];
     }
 
     /**


### PR DESCRIPTION
Appending .0.0 to the string (apparently) doesn't work, causing:

ERROR  meteorApp:  error occurred during checking preconditions:  TypeError: Cannot read property '0' of null

Using parseFloat on the current Meteor version fixes this issue.