### PR TITLE
Catch filesystem error if .desktop/modules doesn't exist

### DIFF
--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -282,7 +282,18 @@ export default class App {
         });
 
         // Now go through each directory in .desktop/modules.
-        fs.readdirSync(join(this.desktopPath, 'modules')).forEach((dirName) => {
+        const moduleDirectories = [];
+        try {
+            moduleDirectories = fs.readdirSync(join(this.desktopPath, 'modules'));
+        } catch (err) {
+            if (err.code == "ENOENT") {
+                this.l.debug(`not loading custom app modules because .desktop/modules isn't a directory`);
+            } else {
+                throw err;
+            }
+        }
+
+        moduleDirectories.forEach((dirName) => {
             try {
                 const modulePath = join(this.desktopPath, 'modules', dirName);
                 if (fs.lstatSync(modulePath).isDirectory()) {


### PR DESCRIPTION
If .desktop/modules doesn't exist, an ENOENT filesystem error is thrown when trying to read the directory. This change catches the error and lets the build continue successfully.