### PR TITLE
Allow dev tools in prod build using electron-builder

### DIFF
--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -87,7 +87,9 @@ export default class App {
         if (this.isProduction()) {
             // In case anything depends on this...
             process.env.NODE_ENV = 'production';
-        } else {
+        } 
+        
+        if (!this.isProduction() || process.env.ELETRON_DEV_TOOLS_PRODUCTION == 'true'){
             require('electron-debug')({
                 showDevTools: process.env.ELECTRON_ENV !== 'test',
                 enabled: (this.settings.devTools !== undefined) ? this.settings.devTools : true


### PR DESCRIPTION
I haven't tested this yet, but this is an attempt to allow dev tools in production build with an environment variable override. I'm assuming env vars from `meteor run` are available in this file, I'm trying to make this possible

```
ELETRON_DEV_TOOLS_PRODUCTION=true meteor-desktop -- build-installer <prod-ddp-url>
```