### PR TITLE
Allow config header Access-Control-Allow-Origin on LocalServer module

### DIFF
--- a/scaffold/settings.json
+++ b/scaffold/settings.json
@@ -13,7 +13,7 @@
     },
     "webAppStartupTimeout": 60000,
     "exposeLocalFilesystem": false,
-    "allowOrigin": false,
+    "allowOriginLocalServer": false,
     "window": {
         "icon": "@assets/meteor.png",
         "_windows": {

--- a/scaffold/settings.json
+++ b/scaffold/settings.json
@@ -13,6 +13,7 @@
     },
     "webAppStartupTimeout": 60000,
     "exposeLocalFilesystem": false,
+    "allowOrigin": false,
     "window": {
         "icon": "@assets/meteor.png",
         "_windows": {

--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -370,7 +370,7 @@ export default class App {
             settings = this.prepareAutoupdateSettings();
         }
         if (internal && moduleName === 'localServer') {
-            settings = { localFilesystem: this.settings.exposeLocalFilesystem };
+            settings = { localFilesystem: this.settings.exposeLocalFilesystem, allowOrigin: this.settings.allowOrigin || false };
         }
 
         this.modules[moduleName] = new AppModule({

--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -370,7 +370,7 @@ export default class App {
             settings = this.prepareAutoupdateSettings();
         }
         if (internal && moduleName === 'localServer') {
-            settings = { localFilesystem: this.settings.exposeLocalFilesystem, allowOrigin: this.settings.allowOrigin || false };
+            settings = { localFilesystem: this.settings.exposeLocalFilesystem, allowOriginLocalServer: this.settings.allowOriginLocalServer || false };
         }
 
         this.modules[moduleName] = new AppModule({

--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -370,7 +370,10 @@ export default class App {
             settings = this.prepareAutoupdateSettings();
         }
         if (internal && moduleName === 'localServer') {
-            settings = { localFilesystem: this.settings.exposeLocalFilesystem, allowOriginLocalServer: this.settings.allowOriginLocalServer || false };
+            settings = {
+                localFilesystem: this.settings.exposeLocalFilesystem,
+                allowOriginLocalServer: this.settings.allowOriginLocalServer || false
+            };
         }
 
         this.modules[moduleName] = new AppModule({

--- a/skeleton/modules/localServer.js
+++ b/skeleton/modules/localServer.js
@@ -342,7 +342,7 @@ export default class LocalServer {
             }
 
             if (self.settings.allowOriginLocalServer) {
-                res.setHeader("Access-Control-Allow-Origin", "*");
+                res.setHeader('Access-Control-Allow-Origin', '*');
             }
 
             const bareUrl = parsedUrl.pathname.substr(urlAlias.length);

--- a/skeleton/modules/localServer.js
+++ b/skeleton/modules/localServer.js
@@ -341,7 +341,7 @@ export default class LocalServer {
                 return next();
             }
 
-            if (self.settings.allowOrigin) {
+            if (self.settings.allowOriginLocalServer) {
                 res.setHeader("Access-Control-Allow-Origin", "*");
             }
 

--- a/skeleton/modules/localServer.js
+++ b/skeleton/modules/localServer.js
@@ -341,6 +341,10 @@ export default class LocalServer {
                 return next();
             }
 
+            if (self.settings.allowOrigin) {
+                res.setHeader("Access-Control-Allow-Origin", "*");
+            }
+
             const bareUrl = parsedUrl.pathname.substr(urlAlias.length);
 
             let filePath;


### PR DESCRIPTION
This will set `allowOriginLocalServer: false` in settings.json when scaffolding

When allowOriginLocalServer is set to true, it will set Access-Control-Allow-Origin = "*" header in LocalServer fileSystem responses.

Referenced issue https://github.com/wojtkowiak/meteor-desktop/issues/215

