### PR TITLE
fix getPackagedAppPath for mac package

### DIFF
--- a/lib/electronBuilder.js
+++ b/lib/electronBuilder.js
@@ -221,6 +221,7 @@ export default class InstallerBuilder {
         if (this.currentContext.platform.nodeName === 'darwin') {
             return path.join(
                 this.installerDir,
+                'mac',
                 `${context.packager.appInfo.productFilename}.app`,
                 'Contents', 'Resources', 'app'
             );


### PR DESCRIPTION
This small fix enable to build macOS package with dependencies.