### PR TITLE
Repaired integration with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ skip_tags: true
 
 environment:
   matrix:
-    - nodejs_version: "10"
+    - nodejs_version: "8"
       test: "normal"
       platform: x64
-    - nodejs_version: "10"
+    - nodejs_version: "8"
       test: "integration"
       platform: x64
 
@@ -30,7 +30,7 @@ install:
   - ps: >-
       if ($env:test -eq "integration") {
         if ((Get-Command "meteor" -ErrorAction SilentlyContinue) -eq $null) {
-          choco install meteor --params "'/RELEASE:1.8.1'"
+          choco install meteor --params "'/RELEASE:1.8.2'"
         }
       }
   - ps: refreshenv


### PR DESCRIPTION
Meteor 1.8.x still uses nodejs v.8, so we should too. Btw, Meteor never used nodejs v.10, they jumped straight to 12 with the release of 1.9

Btw, @wojtkowiak did you consider start testing usage of tests for latest version of Meteor or you just use 1.8.X in production so this isn't relevant for you?